### PR TITLE
change aggregation method to accommodate missing data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ Meta
 vignettes/calculate_speed_delay_cache/
 
 vignettes/data_cache/
+
+vignettes/.DS_Store
+
+vignettes/key_congestion_metrics_cache/
+
+.DS_Store

--- a/R/aggregate_sensor.R
+++ b/R/aggregate_sensor.R
@@ -156,7 +156,7 @@ aggregate_sensor <- function(sensor_data, config, interval_length,
 
     sensor_data_agg <- sensor_data[, as.list(unlist(lapply(.SD, function(x) {
       list(
-        sum =  mean(x, na.rm = T) * n_rows_expected,
+        sum =  round(mean(x, na.rm = T) * n_rows_expected),
         mean = mean(x, na.rm = T),
         pct.null = round(100 * sum(is.na(x)) / length(x))
       )
@@ -186,7 +186,7 @@ aggregate_sensor <- function(sensor_data, config, interval_length,
 
     sensor_data_agg <- sensor_data[, as.list(unlist(lapply(.SD, function(x) {
       list(
-        sum = mean(x, na.rm = T)*n_rows_expected,
+        sum = round(mean(x, na.rm = T)*n_rows_expected),
         mean = mean(x, na.rm = T),
         pct.null = round(100 * sum(is.na(x)) / length(x))
       )

--- a/R/aggregate_sensor.R
+++ b/R/aggregate_sensor.R
@@ -145,6 +145,7 @@ aggregate_sensor <- function(sensor_data, config, interval_length,
   if (interval_length < 1) { # if the interval length is less than an hour
     # browser()
     interval_length_min <- interval_length * 60
+    n_rows_expected <- interval_length_min * 2 # two scans per minute
 
     bins <- seq(0, 60, interval_length * 60)
 
@@ -155,7 +156,7 @@ aggregate_sensor <- function(sensor_data, config, interval_length,
 
     sensor_data_agg <- sensor_data[, as.list(unlist(lapply(.SD, function(x) {
       list(
-        sum = sum(x, na.rm = T),
+        sum =  mean(x, na.rm = T) * n_rows_expected,
         mean = mean(x, na.rm = T),
         pct.null = round(100 * sum(is.na(x)) / length(x))
       )
@@ -173,6 +174,7 @@ aggregate_sensor <- function(sensor_data, config, interval_length,
   } else { # if the interval length is greater than or equal to 1 hour
 
     bins <- seq(0, 24, interval_length)
+    n_rows_expected <- 60 * 2 # two scans per minute
 
     sensor_data[, date := data.table::as.IDate(date)][
       , year := data.table::year(date)
@@ -184,7 +186,7 @@ aggregate_sensor <- function(sensor_data, config, interval_length,
 
     sensor_data_agg <- sensor_data[, as.list(unlist(lapply(.SD, function(x) {
       list(
-        sum = sum(x, na.rm = T),
+        sum = mean(x, na.rm = T)*n_rows_expected,
         mean = mean(x, na.rm = T),
         pct.null = round(100 * sum(is.na(x)) / length(x))
       )

--- a/R/aggregate_sensor.R
+++ b/R/aggregate_sensor.R
@@ -136,6 +136,9 @@ aggregate_sensor <- function(sensor_data, config, interval_length,
   }
 
 
+  interval_length_min <- interval_length * 60
+  n_rows_expected <- interval_length_min * 2 # two scans/observations per minute
+
   # there are 60 scans/second
   # 60*30 = 1,800 scans/ 30 sec (the interval we are given)
   # 60*60 = 3,600 scans/minute
@@ -144,8 +147,6 @@ aggregate_sensor <- function(sensor_data, config, interval_length,
 
   if (interval_length < 1) { # if the interval length is less than an hour
     # browser()
-    interval_length_min <- interval_length * 60
-    n_rows_expected <- interval_length_min * 2 # two scans per minute
 
     bins <- seq(0, 60, interval_length * 60)
 
@@ -167,14 +168,12 @@ aggregate_sensor <- function(sensor_data, config, interval_length,
       , occupancy.pct := (occupancy.sum / interval_scans)
     ][
       , speed := ifelse(volume.sum != 0 & occupancy.pct >= occupancy_pct_threshold,
-        (volume.sum * (60 / interval_length_min) * field_length)
-        / (5280 * occupancy.pct), NA
+                        (volume.sum * (60 / interval_length_min) * field_length)
+                        / (5280 * occupancy.pct), NA
       )
     ]
   } else { # if the interval length is greater than or equal to 1 hour
-
     bins <- seq(0, 24, interval_length)
-    n_rows_expected <- 60 * 2 # two scans per minute
 
     sensor_data[, date := data.table::as.IDate(date)][
       , year := data.table::year(date)
@@ -197,8 +196,8 @@ aggregate_sensor <- function(sensor_data, config, interval_length,
       , occupancy.pct := (occupancy.sum / interval_scans)
     ][
       , speed := ifelse(volume.sum != 0 & occupancy.pct >= occupancy_pct_threshold,
-        ((volume.sum * field_length) /
-          (5280 * occupancy.pct)) / interval_length, NA
+                        ((volume.sum * field_length) /
+                           (5280 * occupancy.pct)) / interval_length, NA
       )
     ]
   }

--- a/R/aggregate_sensor.R
+++ b/R/aggregate_sensor.R
@@ -157,7 +157,7 @@ aggregate_sensor <- function(sensor_data, config, interval_length,
 
     sensor_data_agg <- sensor_data[, as.list(unlist(lapply(.SD, function(x) {
       list(
-        sum =  round(mean(x, na.rm = T) * n_rows_expected),
+        sum = round(mean(x, na.rm = T) * n_rows_expected),
         mean = mean(x, na.rm = T),
         pct.null = round(100 * sum(is.na(x)) / length(x))
       )
@@ -168,8 +168,8 @@ aggregate_sensor <- function(sensor_data, config, interval_length,
       , occupancy.pct := (occupancy.sum / interval_scans)
     ][
       , speed := ifelse(volume.sum != 0 & occupancy.pct >= occupancy_pct_threshold,
-                        (volume.sum * (60 / interval_length_min) * field_length)
-                        / (5280 * occupancy.pct), NA
+        (volume.sum * (60 / interval_length_min) * field_length)
+        / (5280 * occupancy.pct), NA
       )
     ]
   } else { # if the interval length is greater than or equal to 1 hour
@@ -185,7 +185,7 @@ aggregate_sensor <- function(sensor_data, config, interval_length,
 
     sensor_data_agg <- sensor_data[, as.list(unlist(lapply(.SD, function(x) {
       list(
-        sum = round(mean(x, na.rm = T)*n_rows_expected),
+        sum = round(mean(x, na.rm = T) * n_rows_expected),
         mean = mean(x, na.rm = T),
         pct.null = round(100 * sum(is.na(x)) / length(x))
       )
@@ -196,8 +196,8 @@ aggregate_sensor <- function(sensor_data, config, interval_length,
       , occupancy.pct := (occupancy.sum / interval_scans)
     ][
       , speed := ifelse(volume.sum != 0 & occupancy.pct >= occupancy_pct_threshold,
-                        ((volume.sum * field_length) /
-                           (5280 * occupancy.pct)) / interval_length, NA
+        ((volume.sum * field_length) /
+          (5280 * occupancy.pct)) / interval_length, NA
       )
     ]
   }

--- a/tests/testthat/test-aggregate_sensor.R
+++ b/tests/testthat/test-aggregate_sensor.R
@@ -23,8 +23,8 @@ test_that("Aggregation functions as expected", {
     )
     testthat::expect_equal(dim(agg)[[1]], 96)
 
-    testthat::expect_equivalent(sum(sensor_results$volume, na.rm = T), sum(agg$volume.sum, na.rm = T))
-    testthat::expect_equal(sum(sensor_results$occupancy, na.rm = T), sum(agg$occupancy.sum, na.rm = T))
+    testthat::expect_equivalent(round(mean(sensor_results$volume, na.rm = T)),
+                                round(mean(agg$volume.mean, na.rm = T)))
 
     # test aggregation at 1 hour--------------------------------------------------
     agg_hour <- aggregate_sensor(sensor_results,
@@ -32,8 +32,8 @@ test_that("Aggregation functions as expected", {
       config = config_sample
     )
     testthat::expect_equal(dim(agg_hour)[[1]], 24)
-    testthat::expect_equal(sum(sensor_results$volume, na.rm = T), sum(agg_hour$volume.sum))
-    testthat::expect_equal(sum(sensor_results$occupancy, na.rm = T), sum(agg_hour$occupancy.sum))
+    testthat::expect_equal(round(mean(sensor_results$volume, na.rm = T)),
+                           round(mean(agg_hour$volume.mean)))
     ifelse(!is.na(agg$speed),
       testthat::expect_true(round(mean(agg$speed, na.rm = T)) - round(mean(agg_hour$speed, na.rm = T)) < 3), NA
     )
@@ -43,8 +43,8 @@ test_that("Aggregation functions as expected", {
       config = config_sample
     )
     testthat::expect_equal(dim(agg_day)[[1]], 1)
-    testthat::expect_equal(sum(sensor_results$volume, na.rm = T), sum(agg_day$volume.sum))
-    testthat::expect_equal(sum(sensor_results$occupancy, na.rm = T), sum(agg_day$occupancy.sum))
+    testthat::expect_equal(round(mean(sensor_results$volume, na.rm = T)),
+                           round(mean(agg_day$volume.mean)))
     ifelse(!is.na(agg$speed),
       testthat::expect_true(round(mean(agg$speed, na.rm = T)) - round(mean(agg_day$speed, na.rm = T)) < 3), no = NA
     )

--- a/tests/testthat/test-aggregate_sensor.R
+++ b/tests/testthat/test-aggregate_sensor.R
@@ -1,7 +1,7 @@
 testthat::skip_if_offline()
 
-test_that("Aggregation functions as expected", {
-  testthat::try_again(4, {
+testthat::test_that("Aggregation functions as expected", {
+  testthat::try_again(times = 4, code = {
     config <- pull_configuration()
 
     yesterday <- as.Date(Sys.Date() - 3)
@@ -26,6 +26,9 @@ test_that("Aggregation functions as expected", {
     testthat::expect_equivalent(round(mean(sensor_results$volume, na.rm = T)),
                                 round(mean(agg$volume.mean, na.rm = T)))
 
+    testthat::expect_equivalent(sum(sensor_results$occupancy, na.rm = T),
+                           sum(agg$occupancy.sum, na.rm = T))
+
     # test aggregation at 1 hour--------------------------------------------------
     agg_hour <- aggregate_sensor(sensor_results,
       interval_length = 1,
@@ -34,6 +37,9 @@ test_that("Aggregation functions as expected", {
     testthat::expect_equal(dim(agg_hour)[[1]], 24)
     testthat::expect_equal(round(mean(sensor_results$volume, na.rm = T)),
                            round(mean(agg_hour$volume.mean)))
+
+    testthat::expect_equal(sum(sensor_results$occupancy, na.rm = T), sum(agg_hour$occupancy.sum, na.rm = T))
+
     ifelse(!is.na(agg$speed),
       testthat::expect_true(round(mean(agg$speed, na.rm = T)) - round(mean(agg_hour$speed, na.rm = T)) < 3), NA
     )
@@ -45,6 +51,10 @@ test_that("Aggregation functions as expected", {
     testthat::expect_equal(dim(agg_day)[[1]], 1)
     testthat::expect_equal(round(mean(sensor_results$volume, na.rm = T)),
                            round(mean(agg_day$volume.mean)))
+
+    testthat::expect_equal(sum(sensor_results$occupancy, na.rm = T),
+                           sum(agg_day$occupancy.sum, na.rm = T))
+
     ifelse(!is.na(agg$speed),
       testthat::expect_true(round(mean(agg$speed, na.rm = T)) - round(mean(agg_day$speed, na.rm = T)) < 3), no = NA
     )

--- a/tests/testthat/test-aggregate_sensor.R
+++ b/tests/testthat/test-aggregate_sensor.R
@@ -35,7 +35,7 @@ test_that("Aggregation functions as expected", {
     testthat::expect_equal(sum(sensor_results$volume, na.rm = T), sum(agg_hour$volume.sum))
     testthat::expect_equal(sum(sensor_results$occupancy, na.rm = T), sum(agg_hour$occupancy.sum))
     ifelse(!is.na(agg$speed),
-      testthat::expect_equivalent(mean(agg$speed, na.rm = T), mean(agg_hour$speed, na.rm = T)), NA
+      testthat::expect_true(round(mean(agg$speed, na.rm = T)) - round(mean(agg_hour$speed, na.rm = T)) < 3), NA
     )
     # test aggregation at 24 hours------------------------------------------------
     agg_day <- aggregate_sensor(sensor_results,
@@ -46,7 +46,7 @@ test_that("Aggregation functions as expected", {
     testthat::expect_equal(sum(sensor_results$volume, na.rm = T), sum(agg_day$volume.sum))
     testthat::expect_equal(sum(sensor_results$occupancy, na.rm = T), sum(agg_day$occupancy.sum))
     ifelse(!is.na(agg$speed),
-      testthat::expect_equivalent(mean(agg$speed, na.rm = T), mean(agg_day$speed, na.rm = T)), no = NA
+      testthat::expect_true(round(mean(agg$speed, na.rm = T)) - round(mean(agg_day$speed, na.rm = T)) < 3), no = NA
     )
 
     # test argument checks--------------------------------------------------------

--- a/tests/testthat/test-aggregate_sensor.R
+++ b/tests/testthat/test-aggregate_sensor.R
@@ -23,11 +23,15 @@ testthat::test_that("Aggregation functions as expected", {
     )
     testthat::expect_equal(dim(agg)[[1]], 96)
 
-    testthat::expect_equivalent(round(mean(sensor_results$volume, na.rm = T)),
-                                round(mean(agg$volume.mean, na.rm = T)))
+    testthat::expect_equivalent(
+      round(mean(sensor_results$volume, na.rm = T)),
+      round(mean(agg$volume.mean, na.rm = T))
+    )
 
-    testthat::expect_equivalent(sum(sensor_results$occupancy, na.rm = T),
-                           sum(agg$occupancy.sum, na.rm = T))
+    testthat::expect_equivalent(
+      sum(sensor_results$occupancy, na.rm = T),
+      sum(agg$occupancy.sum, na.rm = T)
+    )
 
     # test aggregation at 1 hour--------------------------------------------------
     agg_hour <- aggregate_sensor(sensor_results,
@@ -35,8 +39,10 @@ testthat::test_that("Aggregation functions as expected", {
       config = config_sample
     )
     testthat::expect_equal(dim(agg_hour)[[1]], 24)
-    testthat::expect_equal(round(mean(sensor_results$volume, na.rm = T)),
-                           round(mean(agg_hour$volume.mean)))
+    testthat::expect_equal(
+      round(mean(sensor_results$volume, na.rm = T)),
+      round(mean(agg_hour$volume.mean))
+    )
 
     testthat::expect_equal(sum(sensor_results$occupancy, na.rm = T), sum(agg_hour$occupancy.sum, na.rm = T))
 
@@ -49,11 +55,15 @@ testthat::test_that("Aggregation functions as expected", {
       config = config_sample
     )
     testthat::expect_equal(dim(agg_day)[[1]], 1)
-    testthat::expect_equal(round(mean(sensor_results$volume, na.rm = T)),
-                           round(mean(agg_day$volume.mean)))
+    testthat::expect_equal(
+      round(mean(sensor_results$volume, na.rm = T)),
+      round(mean(agg_day$volume.mean))
+    )
 
-    testthat::expect_equal(sum(sensor_results$occupancy, na.rm = T),
-                           sum(agg_day$occupancy.sum, na.rm = T))
+    testthat::expect_equal(
+      sum(sensor_results$occupancy, na.rm = T),
+      sum(agg_day$occupancy.sum, na.rm = T)
+    )
 
     ifelse(!is.na(agg$speed),
       testthat::expect_true(round(mean(agg$speed, na.rm = T)) - round(mean(agg_day$speed, na.rm = T)) < 3), no = NA

--- a/tests/testthat/test-replace_impossible.R
+++ b/tests/testthat/test-replace_impossible.R
@@ -33,8 +33,8 @@ test_that("Impossible values are replaced", {
     interval_length = NA
   )
 
-  testthat::expect_true(max(imp_rem$volume) < 20 | is.na(max(imp_rem$volume)))
-  testthat::expect_true(max(imp_rem$occupancy) < 1800 | is.na(max(imp_rem$occupancy)))
+  testthat::expect_true(max(imp_rem$volume, na.rm = T) < 20 | is.na(max(imp_rem$volume)))
+  testthat::expect_true(max(imp_rem$occupancy, na.rm = T) < 1800 | is.na(max(imp_rem$occupancy)))
 
   # test aggregation at 15 minutes----------------------------------------------
   agg <- aggregate_sensor(sensor_results,
@@ -43,8 +43,8 @@ test_that("Impossible values are replaced", {
   ) %>%
     replace_impossible(interval_length = 0.25)
 
-  testthat::expect_true(max(agg$volume.sum) < 0.25 * 2300)
-  testthat::expect_true(max(agg$occupancy.sum) < 0.25 * 216000)
+  testthat::expect_true(max(agg$volume.sum, na.rm = T) < 0.25 * 2300)
+  testthat::expect_true(max(agg$occupancy.sum, na.rm = T) < 0.25 * 216000)
 
   testthat::expect_equal(dim(agg)[[1]], 96)
 
@@ -55,8 +55,8 @@ test_that("Impossible values are replaced", {
   ) %>%
     replace_impossible(interval_length = 1)
 
-  testthat::expect_true(max(agg_hour$volume.sum) < 2300)
-  testthat::expect_true(max(agg_hour$occupancy.sum) < 216000)
+  testthat::expect_true(max(agg_hour$volume.sum, na.rm = T) < 2300)
+  testthat::expect_true(max(agg_hour$occupancy.sum, na.rm = T) < 216000)
 
   # test aggregation at 24 hours------------------------------------------------
   agg_day <- aggregate_sensor(sensor_results,
@@ -65,8 +65,8 @@ test_that("Impossible values are replaced", {
   ) %>%
     replace_impossible(interval_length = 24)
 
-  testthat::expect_true(max(agg_day$volume.sum) < 24 * 2300)
-  testthat::expect_true(max(agg_day$occupancy.sum) < 24 * 216000)
+  testthat::expect_true(max(agg_day$volume.sum, na.rm = T) < 24 * 2300)
+  testthat::expect_true(max(agg_day$occupancy.sum, na.rm = T) < 24 * 216000)
 
 
   # test argument checks--------------------------------------------------------


### PR DESCRIPTION
sum(x, na.rm = T) can result in zeros where all values are NA. Changing this to an average, multiplied by the number of expected observations should fix this.